### PR TITLE
Add support for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ matrix:
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
+    - os: linux
+      dist: xenial
+      python: 3.7
+      env: TOXENV=py37
+      sudo: true
     - python: "2.7"
       env: TOXENV=py27
     - python: "3.6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifier =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py36,py35,py34,py27,pep8
+envlist = py37,py36,py35,py34,py27,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Python 3.7 is out and some distros are already using it, so we should
add official support for it. It doesn't appear that any functional
changes are needed. This commit just updates the package metadata and
adds python 3.7 test jobs.