### PR TITLE
Add official support for Python 3.8 and Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
       python: 3.7
       env: TOXENV=py37
       sudo: true
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
     - python: "2.7"
       env: TOXENV=py27
     - python: "3.6"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,10 @@ strategy:
       python.version: '3.6'
     Python37:
       python.version: '3.7'
+    Python38:
+      python.version: '3.8'
+    Python39:
+      python.version: '3.9'
 
 steps:
 - task: UsePythonVersion@0

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,8 @@ classifier =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py37,py36,py35,py34,py27,pep8
+envlist = py39,py38,py37,py36,py35,py34,py27,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This commit adds support for running on Python 3.8 and 3.9. Nothing
actually prevented it from running before but the trove classifiers in
the package metadata and CI jobs were missing for these newer python
versions. This commit addresses this by adding these to the package
metadata and adding CI jobs for Python 3.8 and 3.9.