### PR TITLE
Update supported Python versions and CI config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,18 +10,14 @@ pool:
   vmImage: 'vs2017-win2016'
 strategy:
   matrix:
-    Python27:
-      python.version: '2.7'
-    Python35:
-      python.version: '3.5'
-    Python36:
-      python.version: '3.6'
     Python37:
       python.version: '3.7'
     Python38:
       python.version: '3.8'
     Python39:
       python.version: '3.9'
+    Python310:
+      python.version: '3.10'
 
 steps:
 - task: UsePythonVersion@0

--- a/pyopnsense/diagnostics.py
+++ b/pyopnsense/diagnostics.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyopnsense. If not, see <http://www.gnu.org/licenses/>.
 
-from six.moves import urllib
+import urllib
 
 from pyopnsense import client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@
 # process, which may cause wedges in the gate later.
 
 pbr>=1.6 # Apache-2.0
-six>=1.9.0 # MIT
 requests>=2.14.2 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,21 +2,19 @@
 name = pyopnsense
 summary = A python API client for OPNsense
 homepage = http://github.com/mtreinish/pyopnsense
-description-file =
+description_file =
     README.rst
 author = Matthew Treinish
-author-email = mtreinish@kortar.org
+author_email = mtreinish@kortar.org
 classifier =
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+python_requires = >=3.7
 
 [files]
 packages =


### PR DESCRIPTION
This commit updates the supported list of supported Python versions to
only include currently supported upstream versions of cPython. From this
commit onward only Python 3.7 will be supported. This also enables us to
drop the six dependency as it was only used to maintain Python 2.7
compat. Additionally the Ci configuration is updated to only run tests
for the supported versions of Python.