### PR TITLE
Bump minimum supported Python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,11 +10,11 @@ classifier =
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-python_requires = >=3.7
+    Programming Language :: Python :: 3.11
+python_requires = >=3.8
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py39,py38,py37,py36,py35,py34,py27,pep8
+envlist = py39,py38,py310,py311,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
With the pending upstream cPython EoL for Python 3.7 at the end of June 2023 (the month this is being committed) it is time to drop official support for running pyopnsense on Python 3.7. This commit raises the minimum required Python version to 3.8 and also marks 3.11 as officially supported in the package metadata.