### PR TITLE
Suppress error message "InsecureRequestWarning: Unverified HTTPS requ…

### DIFF
--- a/pyopnsense/client.py
+++ b/pyopnsense/client.py
@@ -21,6 +21,7 @@ import json
 import requests
 
 from pyopnsense import exceptions
+from requests.packages import urllib3
 
 DEFAULT_TIMEOUT = 5
 
@@ -39,6 +40,8 @@ class OPNClient(object):
         self.api_secret = api_secret
         self.base_url = base_url
         self.verify_cert = verify_cert
+        if self.verify_cert == False:
+          urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.timeout = timeout
 
     def _process_response(self, response, raw=False):


### PR DESCRIPTION
…est is being made" if verify_cert is False. This warning is creating a lot of log noise in Home Assistant (https://github.com/home-assistant/core/issues/89094) and probably other projects that use pyopnsense.