### PR TITLE
Change client to accept json data directly

### DIFF
--- a/pyopnsense/client.py
+++ b/pyopnsense/client.py
@@ -60,11 +60,11 @@ class OPNClient(object):
         )
         return self._process_response(response, raw)
 
-    def _post(self, endpoint, body, raw=False):
+    def _post(self, endpoint, data, raw=False):
         req_url = "{}/{}".format(self.base_url, endpoint)
         response = requests.post(
             req_url,
-            data=body,
+            json=data,
             verify=self.verify_cert,
             auth=(self.api_key, self.api_secret),
             timeout=self.timeout,

--- a/pyopnsense/tests/test_client.py
+++ b/pyopnsense/tests/test_client.py
@@ -58,10 +58,10 @@ class TestOPNClient(base.TestCase):
         response_mock.text = json.dumps({"a": "body"})
         request_mock.return_value = response_mock
         opnclient = client.OPNClient("", "", "")
-        resp = opnclient._post("fake_url", "body")
+        resp = opnclient._post("fake_url", {})
         self.assertEqual({"a": "body"}, resp)
         request_mock.assert_called_once_with(
-            "/fake_url", data="body", auth=("", ""), timeout=5, verify=False
+            "/fake_url", json={}, auth=("", ""), timeout=5, verify=False
         )
 
     @mock.patch("requests.post")
@@ -71,7 +71,7 @@ class TestOPNClient(base.TestCase):
         response_mock.text = json.dumps({"a": "body"})
         request_mock.return_value = response_mock
         opnclient = client.OPNClient("", "", "")
-        self.assertRaises(exceptions.APIException, opnclient._post, "fake_url", "body")
+        self.assertRaises(exceptions.APIException, opnclient._post, "fake_url", {})
         request_mock.assert_called_once_with(
-            "/fake_url", data="body", auth=("", ""), timeout=5, verify=False
+            "/fake_url", json={}, auth=("", ""), timeout=5, verify=False
         )


### PR DESCRIPTION
since requests can handle python dictionaries directly I suggest to change the _post behaviour to accept python dictionaries directly and hand it over to requests for converting it to json automatically